### PR TITLE
Fix left pointer of 28 bit records.

### DIFF
--- a/Data/GeoIP2/SearchTree.hs
+++ b/Data/GeoIP2/SearchTree.hs
@@ -25,7 +25,7 @@ readNode mem recordbits index =
     bytes = BS.take (fromIntegral bytecount) $ BS.drop (fromIntegral $ index * bytecount) mem
     num = BS.foldl' (\acc new -> fromIntegral new + 256 * acc) 0 bytes :: Word64
     -- 28 bits has a strange record format
-    left28 = num `shift` (-32) .|. (num .&. 0xf0000000)
+    left28 = num `shift` (-32) .|. (num .&. 0xf0000000) `shift` (-4)
   in case recordbits of
       28 -> (fromIntegral left28, fromIntegral (num .&. ((1 `shift` recordbits) - 1)))
       _  -> (fromIntegral (num `shift` negate recordbits), fromIntegral (num .&. ((1 `shift` recordbits) - 1)))


### PR DESCRIPTION
The left nibble of the middle byte in the 28 bit format was not correctly shifted prior to combining it with the other 3 bytes of the left pointer. Namely, in the following 28 bit node structure where `XXXX` denotes the most-significant bits of the left pointer

`LLLLLLLL LLLLLLLL LLLLLLLL XXXXRRRR RRRRRRRR RRRRRRRR RRRRRRRR`

the left pointer would end up incorrectly as

`XXXX0000 LLLLLLLL LLLLLLLL LLLLLLLL`

instead of

`0000XXXX LLLLLLLL LLLLLLLL LLLLLLLL`

due to a missing shift of 4 bits. The result is that any left pointer which has any of the most-significant bits set will not resolve correctly, as it will yield a pointer that typically goes beyond the size of the mmapped bytestring, which manifests itself as errors of the form `Left "too few bytes\nFrom:\tdemandInput\n\n"`.
