### PR TITLE
Add timezome field

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# 0.3.0.0
+- Include timezone and accuracy in location results
+
 # 0.2.0.1
 - Fixed a problem with correct decoding of 28-bit offsets
 

--- a/Data/GeoIP2.hs
+++ b/Data/GeoIP2.hs
@@ -119,6 +119,13 @@ data GeoResult = GeoResult {
   , geoSubdivisions  :: [(T.Text, T.Text)]
 } deriving (Show, Eq)
 
+data Location = Location {
+    locationAccuracy :: Int
+    locationLatitude :: Double
+    locationLatitude :: Double
+    locationTimezone :: T.Text
+} deriving (Show, Eq)
+
 -- | Search GeoIP database
 findGeoData ::
      GeoDB   -- ^ Db handle

--- a/Data/GeoIP2.hs
+++ b/Data/GeoIP2.hs
@@ -113,17 +113,17 @@ data GeoResult = GeoResult {
   , geoContinentCode :: Maybe T.Text
   , geoCountryISO    :: Maybe T.Text
   , geoCountry       :: Maybe T.Text
-  , geoLocation      :: Maybe (Double, Double)
+  , geoLocation      :: Maybe Location
   , geoCity          :: Maybe T.Text
   , geoPostalCode    :: Maybe T.Text
   , geoSubdivisions  :: [(T.Text, T.Text)]
 } deriving (Show, Eq)
 
 data Location = Location {
-    locationAccuracy :: Int
     locationLatitude :: Double
-    locationLatitude :: Double
-    locationTimezone :: T.Text
+  , locationLongitude :: Double
+  , locationTimezone :: T.Text
+  , locationAccuracy :: Int
 } deriving (Show, Eq)
 
 -- | Search GeoIP database
@@ -141,7 +141,10 @@ findGeoData geodb lang ip = do
                      (res .:? "continent" ..? "code")
                      (res .:? "country" ..? "iso_code")
                      (res .:? "country" ..? "names" ..? lang)
-                     ((,) <$> res .:? "location" ..? "latitude" <*> res .:? "location" ..? "longitude")
+                     (Location <$> res .:? "location" ..? "latitude"
+                        <*> res .:? "location" ..? "longitude"
+                        <*> res .:? "location" ..? "time_zone"
+                        <*> res .:? "location" ..? "accuracy_radius")
                      (res .:? "city" ..? "names" ..? lang)
                      (res .:? "postal" ..? "code")
                      (fromMaybe [] subdivs)

--- a/geoip2.cabal
+++ b/geoip2.cabal
@@ -1,5 +1,5 @@
 name:                geoip2
-version:             0.2.2.0
+version:             0.3.0.0
 synopsis:            Pure haskell interface to MaxMind GeoIP database
 description:
   GeoIP2 is a haskell binding to the MaxMind GeoIP2 database.


### PR DESCRIPTION
I'm in the need of using the timezone, this changes make it available and already staring to use this particular commit in my code. So if you consider this is not the direction you'd like to take *geoip2*, please feel free to dismiss this PR :)  @ondrap 

Having the location as `(Double, Double)` is pretty obvious what it means, but introducing the timezone (and accuracy) in there like `(Double, Double, Int, Text)` is not longer that obvious and the readability decreases quite a lot, so if this is going to be a API backwards compatibility breakage anyways I might as well introduce a more descriptive datatype, hence `Location`.