### PR TITLE
Fix building with ghc-8.6.1.

### DIFF
--- a/Data/GeoIP2.hs
+++ b/Data/GeoIP2.hs
@@ -134,7 +134,7 @@ findGeoData ::
   -> IP      -- ^ IP address to search
   -> Either String GeoResult -- ^ Result, if something is found
 findGeoData geodb lang ip = do
-  (DataMap res) <- rawGeoData geodb ip
+  res <- rawGeoData geodb ip >>= asMap
   let subdivmap = res .:? "subdivisions" :: Maybe [Map.Map GeoField GeoField]
       subdivs = mapMaybe (\s -> (,) <$> s .:? "iso_code" <*> s .:? "names" ..? lang) <$> subdivmap
 
@@ -149,3 +149,6 @@ findGeoData geodb lang ip = do
                      (res .:? "city" ..? "names" ..? lang)
                      (res .:? "postal" ..? "code")
                      (fromMaybe [] subdivs)
+  where
+    asMap (DataMap res) = return res
+    asMap _             = Left "rawGeoData returned something else than DataMap"


### PR DESCRIPTION
Building with ghc-8.6.1 no longer works as `Either String` does not implement `MonadFail`. Thus I fixed it by removing the non-exhaustive pattern. The error from ghc:

```
Building library for geoip2-0.3.1.0..
[1 of 3] Compiling Data.GeoIP2.Fields ( Data/GeoIP2/Fields.hs, dist/dist-sandbox-af21ab8a/build/Data/GeoIP2/Fields.o )

Data/GeoIP2/Fields.hs:94:13: warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In a multi-way if alternative:
        Guards do not cover entire pattern space
   |
94 |             | ftype == 1 -> do
   |             ^^^^^^^^^^^^^^^^^^...
[2 of 3] Compiling Data.GeoIP2.SearchTree ( Data/GeoIP2/SearchTree.hs, dist/dist-sandbox-af21ab8a/build/Data/GeoIP2/SearchTree.o )
[3 of 3] Compiling Data.GeoIP2      ( Data/GeoIP2.hs, dist/dist-sandbox-af21ab8a/build/Data/GeoIP2.o )

Data/GeoIP2.hs:137:3: error:
    • No instance for (Control.Monad.Fail.MonadFail (Either String))
        arising from a do statement
        with the failable pattern ‘(DataMap res)’
    • In a stmt of a 'do' block: (DataMap res) <- rawGeoData geodb ip
      In the expression:
        do (DataMap res) <- rawGeoData geodb ip
           let subdivmap = ...
               subdivs = mapMaybe (\ s -> ...) <$> subdivmap
           return
             $ GeoResult
                 (res .:? "continent" ..? "names" ..? lang)
                 (res .:? "continent" ..? "code")
                 (res .:? "country" ..? "iso_code")
                 (res .:? "country" ..? "names" ..? lang)
                 (Location <$> res .:? "location" ..? "latitude"
                    <*> res .:? "location" ..? "longitude"
                    <*> res .:? "location" ..? "time_zone"
                    <*> res .:? "location" ..? "accuracy_radius")
                 (res .:? "city" ..? "names" ..? lang)
                 (res .:? "postal" ..? "code")
                 (fromMaybe [] subdivs)
      In an equation for ‘findGeoData’:
          findGeoData geodb lang ip
            = do (DataMap res) <- rawGeoData geodb ip
                 let subdivmap = ...
                     ....
                 return
                   $ GeoResult
                       (res .:? "continent" ..? "names" ..? lang)
                       (res .:? "continent" ..? "code")
                       (res .:? "country" ..? "iso_code")
                       (res .:? "country" ..? "names" ..? lang)
                       (Location <$> res .:? "location" ..? "latitude"
                          <*> res .:? "location" ..? "longitude"
                          <*> res .:? "location" ..? "time_zone"
                          <*> res .:? "location" ..? "accuracy_radius")
                       (res .:? "city" ..? "names" ..? lang)
                       (res .:? "postal" ..? "code")
                       (fromMaybe [] subdivs)
    |
137 |   (DataMap res) <- rawGeoData geodb ip
    |   
```

It would be nice to have a fix for this on hackage so one can build directly with cabal and ghc-8.6.1.