### PR TITLE
Fix DataBool handling

### DIFF
--- a/Data/GeoIP2/Fields.hs
+++ b/Data/GeoIP2/Fields.hs
@@ -108,7 +108,7 @@ instance Serialize GeoFieldRaw where
         8 -> DataWord <$> parseNumber fsize
         9 -> DataWord <$> parseNumber fsize
         11 -> DataArray <$> replicateM (fromIntegral fsize) get
-        14 -> return $ DataBool (fsize == 0)
+        14 -> return $ DataBool (fsize == 1)
         _ -> do
           _ <- getBytes (fromIntegral fsize)
           return $ DataUnknown ftype fsize


### PR DESCRIPTION
Boolean values were handled incorrectly, as discovered with `is_in_european_union` field of paid GeoIP2 databases. While the specification may be misleading, apparently 1 is true and 0 is false.
> A true or false value. The length information for a boolean type will always be 0 or 1, indicating the value